### PR TITLE
Removed uppercase from name of package as npm will not allow publishing ...

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "MutationObservers",
+  "name": "mutationobservers",
   "version": "0.0.0",
-  "description": "ERROR: No README.md file found!",
+  "description": "MutationObservers polyfill from Polymer project.",
   "main": "MutationObserver.js",
   "directories": {
     "test": "test"


### PR DESCRIPTION
...uppercase packages, better description.

I've published this package to `npm` but I'd be more than happy to delete it when the Polymer team wish to publish to `npm`. One note about publishing to `npm` some of your packages have upper case names/directory names which aren't allowed in `npm` and therefore the `script` tag that are written to the document to load other parts of the polyfills will no longer work so when things are published to `npm` package names will all have to be lower cased.
