### PR TITLE
Don't expose webkit prefixed MutationObserver as stable

### DIFF
--- a/MutationObserver.js
+++ b/MutationObserver.js
@@ -539,10 +539,6 @@
 
   global.JsMutationObserver = JsMutationObserver;
 
-  // Provide unprefixed MutationObserver with native or JS implementation
-  if (!global.MutationObserver && global.WebKitMutationObserver)
-    global.MutationObserver = global.WebKitMutationObserver;
-
   if (!global.MutationObserver)
     global.MutationObserver = JsMutationObserver;
 


### PR DESCRIPTION
Older prefixed versions have known issues like not generating mutation records on initial parse.

As suggested by @arv in #16.

Closes #16.
