### PR TITLE
Update MutationObserver.js

### DIFF
--- a/MutationObserver.js
+++ b/MutationObserver.js
@@ -4,9 +4,19 @@
  * license that can be found in the LICENSE file.
  */
 
-(function(global) {
+if (typeof MutationObserver != 'function') (function(global) {
 
-  var registrationsTable = new WeakMap();
+  var registrationsTable = new (function(){
+			var weakMapMinimalVALUE = [], weakMapMinimalKEY = [];
+			this.get = function(key){
+				return weakMapMinimalVALUE[weakMapMinimalKEY.indexOf(key)];
+			};
+			this.set = function(key, value){
+				var keycur = weakMapMinimalKEY.indexOf(key);
+				if (!~keycur) weakMapMinimalKEY[keycur = weakMapMinimalKEY.length] = key;
+				weakMapMinimalVALUE[keycur] = value;
+			};
+		}); //new WeakMap(); // WeakMaps are not supported in IE10 or IE9, same as MutationObservers
 
   // We use setImmediate or postMessage for our future callback.
   var setImmediate = window.msSetImmediate;

--- a/MutationObserver.js
+++ b/MutationObserver.js
@@ -4,7 +4,7 @@
  * license that can be found in the LICENSE file.
  */
 
-if (typeof MutationObserver != 'function') (function(global) {
+if (typeof MutationObserver !== 'function') (function(global) {
 
   var registrationsTable = new (function(){
 			var weakMapMinimalVALUE = [], weakMapMinimalKEY = [];


### PR DESCRIPTION
I think this awesome MutationObserver polyfill should have it's own self-contained weakmap polyfill. This is because the way this polyfill currently is, anyone who doesn't inspect the source code carefully enough or doesn't enough background knowledge to know that Weak Maps are not supported in IE9 or IE10, or anyone who doesn't want to go through the effort of applying these simple changes themselves, is in for a headache when they IE test their website.